### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,7 @@ Tests with `HHVM` fail because of `phpseclib/phpseclib` which is not compatible.
 
 The preferred way to install this library is to rely on Composer:
 
-    {
-        "require": {
-            // ...
-            "spomky-labs/jose": "~0.0.0"
-        }
-    }
+    composer require spomky-labs/jose
 
 ## Extend the library ##
 


### PR DESCRIPTION
- the command line is less verbose / easier to maintain
- there is no need to specify the version constraint, Composer is now
  able to figure out by itself a suitable version constraint. In the
current case, it is not very sexy : 0.0.2.*, but as soon as a stable
release is out, things like ~1.0 will be used.