### PR TITLE
Add importing a minimal JWK

### DIFF
--- a/src/Util/BigInteger.php
+++ b/src/Util/BigInteger.php
@@ -149,6 +149,20 @@ final class BigInteger
     }
 
     /**
+     * Divides two BigIntegers.
+     *
+     * @param BigInteger $x
+     *
+     * @return BigInteger
+     */
+    public function divide(BigInteger $x)
+    {
+        $value = gmp_div($this->value, $x->value);
+
+        return self::createFromGMPResource($value);
+    }
+
+    /**
      * Performs modular exponentiation.
      *
      * @param \Jose\Util\BigInteger $e
@@ -193,6 +207,20 @@ final class BigInteger
     }
 
     /**
+     * Calculates the greatest common denominator.
+     *
+     * @param BigInteger $x
+     *
+     * @return BigInteger
+     */
+    public function gcd(BigInteger $x)
+    {
+        $value = gmp_gcd($this->value, $x->value);
+
+        return self::createFromGMPResource($value);
+    }
+
+    /**
      * Compares two numbers.
      *
      * @param \Jose\Util\BigInteger $y
@@ -202,5 +230,45 @@ final class BigInteger
     public function compare(BigInteger $y)
     {
         return gmp_cmp($this->value, $y->value);
+    }
+
+    /**
+     * Check whether two BigIntegers are the same.
+     *
+     * @param BigInteger $x
+     *
+     * @return bool
+     */
+    public function equals(BigInteger $x)
+    {
+        return 0 === gmp_cmp($this->value, $x->value);
+    }
+
+    /**
+     * Whether this is an even number.
+     *
+     * @return bool
+     */
+    public function isEven()
+    {
+        $zero = self::createFromDecimal(0);
+        $two = self::createFromDecimal(2);
+
+        return $this->mod($two)->equals($zero);
+    }
+
+    /**
+     * Generate a random integer between min and max.
+     *
+     * @param BigInteger $min
+     * @param BigInteger $max
+     *
+     * @return BigInteger
+     */
+    public static function randomInt(BigInteger $min, BigInteger $max)
+    {
+        $value = gmp_random_range($min->value, $max->value);
+
+        return self::createFromGMPResource($value);
     }
 }

--- a/tests/Unit/Keys/RSAKeysTest.php
+++ b/tests/Unit/Keys/RSAKeysTest.php
@@ -228,6 +228,38 @@ class RSAKeysTest extends TestCase
         $this->assertFalse($public_key->isPrivate());
     }
 
+    public function testLoadPrivateRSAKeyFromMinimalValues()
+    {
+        $rsa_key = new RSAKey([
+            'kty' => 'RSA',
+            'n' => 'gVf-iyhwLn2J2Up4EKjwdLYmk5n24gjGk4oQkCHVcE7j8wkS1iSzcu0ApVcMPLklEp_PWycZE12vL90gPeVjF2IPL_MKFL0b6Wy7A1f4kCDkKv7TDDjt1IIwbS-Jdp-2pG7bPb3tWjJUu6QZBLoXfRtW3cMDkQjXaVGixENORLAZs6qdu2MMKV94jetCiFd0JYCjxGVC0HW2OKnM21B_2R1NubOvMlWA7gypdpvmBYDGpkw4mjV3walWlCZObG7IH84Ovl7wOP8XLzqi2un4e6fNzy3rdp4OUSPYItF4ZX5qThWYY2R47Z5sbrZxHjNeDECKUeio0KPQNrgr6FSKSw',
+            'e' => 'AQAB',
+            'd' => 'JSqz6ijkk3dfdSEA_0iMT_1HeIJ1ft4msZ6qw7_1JSCGQAALeZ1yM0QHO3uX-Jr7HC7v1rGVcwsonAhei2qu3rk-w_iCnRL6QkkMNBnDQycwaWpwGsMBFF-UqstOJNggE4AHX-aDnbd4wbKVvdX7ieehPngbPkHcJFdg_iSZCQNoajz6XfEruyIi7_IFXYEGmH_UyEbQkgNtriZysutgYdolUjo9flUlh20HbuV3NwsPjGyDG4dUMpNpdBpSuRHYKLX6h3FjeLhItBmhBfuL7d-G3EXwKlwfNXXYivqY5NQAkFNrRbvFlc_ARIws3zAfykPDIWGWFiPiN3H-hXMgAQ',
+        ]);
+
+        $this->assertEquals([
+            'kty' => 'RSA',
+            'n' => 'gVf-iyhwLn2J2Up4EKjwdLYmk5n24gjGk4oQkCHVcE7j8wkS1iSzcu0ApVcMPLklEp_PWycZE12vL90gPeVjF2IPL_MKFL0b6Wy7A1f4kCDkKv7TDDjt1IIwbS-Jdp-2pG7bPb3tWjJUu6QZBLoXfRtW3cMDkQjXaVGixENORLAZs6qdu2MMKV94jetCiFd0JYCjxGVC0HW2OKnM21B_2R1NubOvMlWA7gypdpvmBYDGpkw4mjV3walWlCZObG7IH84Ovl7wOP8XLzqi2un4e6fNzy3rdp4OUSPYItF4ZX5qThWYY2R47Z5sbrZxHjNeDECKUeio0KPQNrgr6FSKSw',
+            'e' => 'AQAB',
+            'p' => 'pxyF-Ao17wl4ADI0YSsNYm9OzZz6AZD9cUxbxvX-z3yR_vH2GExdcOht5UD9Ij9r0ZyHKkmWGKCtrYzr-Qi2ia2vyiZU0wGmxR_fadHnkxfIqW78ME5C-xGoWLBtHlTaPCWSEmv3p5vM2fqZeUdqTxzb0bQABt0fI6HPjvBlI0s',
+            'd' => 'JSqz6ijkk3dfdSEA_0iMT_1HeIJ1ft4msZ6qw7_1JSCGQAALeZ1yM0QHO3uX-Jr7HC7v1rGVcwsonAhei2qu3rk-w_iCnRL6QkkMNBnDQycwaWpwGsMBFF-UqstOJNggE4AHX-aDnbd4wbKVvdX7ieehPngbPkHcJFdg_iSZCQNoajz6XfEruyIi7_IFXYEGmH_UyEbQkgNtriZysutgYdolUjo9flUlh20HbuV3NwsPjGyDG4dUMpNpdBpSuRHYKLX6h3FjeLhItBmhBfuL7d-G3EXwKlwfNXXYivqY5NQAkFNrRbvFlc_ARIws3zAfykPDIWGWFiPiN3H-hXMgAQ',
+            'q' => 'xiSp6dbdYGINxtklTJlzVr91u_GJzWqyyA4t0jhuWrQN7dLW0s_3I9x6Pdk5U19j0iLWBwcutY9e5SyWPoF0lYVIowZeW0jNiOtv0NthayJ3HJpPk8kj6sVlH0y4sKN_WWHhU5leTwOpr8IG-yohKRyV6Xwhu_JLkzKKWod21QE',
+            'dp' => 'pYUyCNGMRDx7uK4BhbEP68zWIAB4_K4w6lS4nuQvRDJdpUjh-YVCFECUATwSviZVU-QXWUJTwgb8n-byH9OKgeogMTkwUWPUXHHKZ1T6a45mObRtZCdQXsBJn7b4Dc_77RFFkquQPFqsV8fI1gBvgvbRn-8LC8FfQ3rVS_4-Hus',
+            'dq' => 'rNTcNPFLhj_hPnq4UzliZt94RaipB7mzGldr1nuMnqeBotmOsrHeI7S0F_C7VSLWgjwKrnSwZIQbRRGAOCNZWva4ZiMu-LbnOTAMB4TkU7vrY9Kh6QnAv47Q5t1YGBN1CLUdA3u6zHcocvtudXTJGgAqL1AsaLEvBMVH8zFIEQE',
+            'qi' => 'bbFp1zSfnmmOUYUtbaKhmFofn0muf1PrnMGq6zeu8zruf3gK9Y1oDsUk54FlV0mNBO3_t3Zbw2752CLklt73zesVeF-Nsc1kDnx_WGf4YrQpLh5PvkEfT_wPbveKTTcVXiVxMPHHZ-n2kOe3oyShycSLP5_I_SYN-loZHu7QC_I',
+        ], $rsa_key->toArray());
+
+        $this->assertTrue($rsa_key->isPrivate());
+
+        $public_key = RSAKey::toPublic($rsa_key);
+        $this->assertEquals([
+            'kty' => 'RSA',
+            'n'   => 'gVf-iyhwLn2J2Up4EKjwdLYmk5n24gjGk4oQkCHVcE7j8wkS1iSzcu0ApVcMPLklEp_PWycZE12vL90gPeVjF2IPL_MKFL0b6Wy7A1f4kCDkKv7TDDjt1IIwbS-Jdp-2pG7bPb3tWjJUu6QZBLoXfRtW3cMDkQjXaVGixENORLAZs6qdu2MMKV94jetCiFd0JYCjxGVC0HW2OKnM21B_2R1NubOvMlWA7gypdpvmBYDGpkw4mjV3walWlCZObG7IH84Ovl7wOP8XLzqi2un4e6fNzy3rdp4OUSPYItF4ZX5qThWYY2R47Z5sbrZxHjNeDECKUeio0KPQNrgr6FSKSw',
+            'e'   => 'AQAB',
+        ], $public_key->toArray());
+        $this->assertFalse($public_key->isPrivate());
+    }
+
     public function testConvertPrivateKeyToPublic()
     {
         $private_ec_key = new RSAKey([


### PR DESCRIPTION
As stated in section 6.3.2 of RFC 7518 (JWA), JWK private keys
containing only the n, e and d parameters are valid.

This make sure these keys can be imported by finding the p and q factors
when loading the JWK parameters, just as is already done with the dp, dq
and qi parameters.

Closes #158