### PR TITLE
Add interval argument for rotatable key set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+
+phpunit.xml
+composer.lock

--- a/examples/NestedTokens.php
+++ b/examples/NestedTokens.php
@@ -72,4 +72,3 @@ $jwe = JWEFactory::createJWEToCompactJSON(
         'zip' => 'DEF',
     ]
 );
-var_dump($jwe);

--- a/src/Factory/JWKFactory.php
+++ b/src/Factory/JWKFactory.php
@@ -60,9 +60,9 @@ final class JWKFactory implements JWKFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public static function createRotatableKeySet($filename, array $parameters, $nb_keys)
+    public static function createRotatableKeySet($filename, array $parameters, $nb_keys, $interval = null)
     {
-        return new RotatableJWKSet($filename, $parameters, $nb_keys);
+        return new RotatableJWKSet($filename, $parameters, $nb_keys, $interval);
     }
 
     /**

--- a/src/Factory/JWKFactoryInterface.php
+++ b/src/Factory/JWKFactoryInterface.php
@@ -40,13 +40,14 @@ interface JWKFactoryInterface
     public static function createStorableKeySet($filename, array $parameters, $nb_keys);
 
     /**
-     * @param string $filename
-     * @param array  $parameters
-     * @param int    $nb_keys
+     * @param string   $filename
+     * @param array    $parameters
+     * @param int      $nb_keys
+     * @param int|null $interval
      *
      * @return \Jose\Object\JWKSetInterface
      */
-    public static function createRotatableKeySet($filename, array $parameters, $nb_keys);
+    public static function createRotatableKeySet($filename, array $parameters, $nb_keys, $interval = null);
 
     /**
      * @param string $filename

--- a/src/Object/BaseJWKSet.php
+++ b/src/Object/BaseJWKSet.php
@@ -16,7 +16,7 @@ use Assert\Assertion;
 /**
  * Class BaseJWKSet.
  */
-trait BaseJWKSet
+abstract class BaseJWKSet
 {
     /**
      * @var int

--- a/src/Object/BaseJWKSet.php
+++ b/src/Object/BaseJWKSet.php
@@ -172,7 +172,8 @@ trait BaseJWKSet
         Assertion::nullOrString($algorithm);
 
         $result = [];
-        foreach ($this->getKeys() as $key) {
+        $keys = $this->getKeys();
+        foreach ($keys as $key) {
             $ind = 0;
 
             // Check usage

--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -17,9 +17,8 @@ use Psr\Cache\CacheItemPoolInterface;
 /**
  * Class DownloadedJWKSet.
  */
-abstract class DownloadedJWKSet implements JWKSetInterface
+abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
 {
-    use BaseJWKSet;
     use JWKSetPEM;
 
     /**

--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -81,6 +81,14 @@ abstract class DownloadedJWKSet implements JWKSetInterface
     /**
      * {@inheritdoc}
      */
+    public function prependKey(JWKInterface $key)
+    {
+        //Not available
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeKey($index)
     {
         //Not available

--- a/src/Object/JWKSet.php
+++ b/src/Object/JWKSet.php
@@ -52,6 +52,14 @@ final class JWKSet implements JWKSetInterface
     /**
      * {@inheritdoc}
      */
+    public function prependKey(JWKInterface $key)
+    {
+        array_unshift($this->keys, $key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeKey($key)
     {
         if (isset($this->keys[$key])) {

--- a/src/Object/JWKSet.php
+++ b/src/Object/JWKSet.php
@@ -14,9 +14,8 @@ namespace Jose\Object;
 /**
  * Class JWKSet.
  */
-final class JWKSet implements JWKSetInterface
+final class JWKSet extends BaseJWKSet implements JWKSetInterface
 {
-    use BaseJWKSet;
     use JWKSetPEM;
 
     /**
@@ -62,7 +61,7 @@ final class JWKSet implements JWKSetInterface
      */
     public function removeKey($key)
     {
-        if (isset($this->keys[$key])) {
+        if (array_key_exists($key, $this->keys)) {
             unset($this->keys[$key]);
         }
     }

--- a/src/Object/JWKSetInterface.php
+++ b/src/Object/JWKSetInterface.php
@@ -14,14 +14,18 @@ namespace Jose\Object;
 interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \ArrayAccess
 {
     /**
-     * @param $index
+     * Get key from set at index
+     * 
+     * @param int $index
      *
      * @return \Jose\Object\JWKInterface
      */
     public function getKey($index);
 
     /**
-     * @param $index
+     * Check if set has key at index 
+     * 
+     * @param int $index
      *
      * @return bool
      */
@@ -37,7 +41,7 @@ interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \Arr
     /**
      * Add key in the key set.
      *
-     * @param \Jose\Object\JWKInterface A key to store in the key set
+     * @param \Jose\Object\JWKInterface $key A key to store in the key set
      */
     public function addKey(JWKInterface $key);
     

--- a/src/Object/JWKSetInterface.php
+++ b/src/Object/JWKSetInterface.php
@@ -40,6 +40,13 @@ interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \Arr
      * @param \Jose\Object\JWKInterface A key to store in the key set
      */
     public function addKey(JWKInterface $key);
+    
+    /**
+     * Prepend key to the set
+     * 
+     * @param \Jose\Object\JWKInterface $key A key to store in the key set
+     */
+    public function prependKey(JWKInterface $key);
 
     /**
      * Remove key from the key set.

--- a/src/Object/JWKSetInterface.php
+++ b/src/Object/JWKSetInterface.php
@@ -14,8 +14,8 @@ namespace Jose\Object;
 interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \ArrayAccess
 {
     /**
-     * Get key from set at index
-     * 
+     * Get key from set at index.
+     *
      * @param int $index
      *
      * @return \Jose\Object\JWKInterface
@@ -23,8 +23,8 @@ interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \Arr
     public function getKey($index);
 
     /**
-     * Check if set has key at index 
-     * 
+     * Check if set has key at index.
+     *
      * @param int $index
      *
      * @return bool
@@ -44,10 +44,10 @@ interface JWKSetInterface extends \Countable, \Iterator, \JsonSerializable, \Arr
      * @param \Jose\Object\JWKInterface $key A key to store in the key set
      */
     public function addKey(JWKInterface $key);
-    
+
     /**
-     * Prepend key to the set
-     * 
+     * Prepend key to the set.
+     *
      * @param \Jose\Object\JWKInterface $key A key to store in the key set
      */
     public function prependKey(JWKInterface $key);

--- a/src/Object/JWKSets.php
+++ b/src/Object/JWKSets.php
@@ -74,6 +74,14 @@ final class JWKSets implements JWKSetsInterface
     /**
      * {@inheritdoc}
      */
+    public function prependKey(JWKInterface $key)
+    {
+        //Not available
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeKey($index)
     {
         //Not available

--- a/src/Object/JWKSets.php
+++ b/src/Object/JWKSets.php
@@ -16,9 +16,8 @@ use Assert\Assertion;
 /**
  * Class JWKSets.
  */
-final class JWKSets implements JWKSetsInterface
+final class JWKSets extends BaseJWKSet implements JWKSetsInterface
 {
-    use BaseJWKSet;
     use JWKSetPEM;
 
     /**

--- a/src/Object/PublicJWKSet.php
+++ b/src/Object/PublicJWKSet.php
@@ -62,6 +62,14 @@ final class PublicJWKSet implements JWKSetInterface
     /**
      * {@inheritdoc}
      */
+    public function prependKey(JWKInterface $key)
+    {
+        $this->jwkset->prependKey($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function removeKey($index)
     {
         //Not available

--- a/src/Object/PublicJWKSet.php
+++ b/src/Object/PublicJWKSet.php
@@ -14,9 +14,8 @@ namespace Jose\Object;
 /**
  * Class PublicJWKSet.
  */
-final class PublicJWKSet implements JWKSetInterface
+final class PublicJWKSet extends BaseJWKSet implements JWKSetInterface
 {
-    use BaseJWKSet;
     use JWKSetPEM;
 
     /**

--- a/src/Object/RotatableJWKSet.php
+++ b/src/Object/RotatableJWKSet.php
@@ -17,15 +17,19 @@ namespace Jose\Object;
 final class RotatableJWKSet extends StorableJWKSet implements RotatableInterface
 {
     /**
-     * Interval at which keys should be rotated
+     * Interval at which keys should be rotated.
+     *
      * @var int|null
      */
     private $interval;
 
     /**
-     * {@inheritdoc}
+     * RotatableJWKSet constructor.
      *
-     * @param int|null $interval Interval at which to rotate keys
+     * @param string   $filename
+     * @param array    $parameters
+     * @param int      $nb_keys
+     * @param int|null $interval
      */
     public function __construct($filename, array $parameters, $nb_keys, $interval = null)
     {
@@ -41,6 +45,7 @@ final class RotatableJWKSet extends StorableJWKSet implements RotatableInterface
     {
         // Check if we need to rotate keys upon every interaction with the underlying JWK set
         $this->rotateIfNeeded();
+
         return parent::getJWKSet();
     }
 
@@ -62,7 +67,7 @@ final class RotatableJWKSet extends StorableJWKSet implements RotatableInterface
     }
 
     /**
-     * Rotate key set if last modification time is due
+     * Rotate key set if last modification time is due.
      */
     private function rotateIfNeeded()
     {

--- a/src/Object/RotatableJWKSet.php
+++ b/src/Object/RotatableJWKSet.php
@@ -14,24 +14,66 @@ namespace Jose\Object;
 /**
  * Class RotatableJWKSet.
  */
-final class RotatableJWKSet extends StorableJWKSet implements RotatableInterface, JWKSetInterface
+final class RotatableJWKSet extends StorableJWKSet implements RotatableInterface
 {
+    /**
+     * Interval at which keys should be rotated
+     * @var int|null
+     */
+    private $interval;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param int|null $interval Interval at which to rotate keys
+     */
+    public function __construct($filename, array $parameters, $nb_keys, $interval = null)
+    {
+        parent::__construct($filename, $parameters, $nb_keys);
+
+        $this->interval = $interval;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJWKSet()
+    {
+        // Check if we need to rotate keys upon every interaction with the underlying JWK set
+        $this->rotateIfNeeded();
+        return parent::getJWKSet();
+    }
+
     /**
      * {@inheritdoc}
      */
     public function rotate()
     {
-        $this->loadObjectIfNeeded();
-        $jwkset = $this->getObject();
+        $jwkset = parent::getJWKSet();
 
-        $keys = $jwkset->getKeys();
-        unset($keys[count($keys) - 1]);
-        $jwkset = new JWKSet();
-        $jwkset->addKey($this->createJWK());
-        foreach ($keys as $key) {
-            $jwkset->addKey($key);
-        }
-        $this->setObject($jwkset);
+        // Remove last key in set
+        $jwkset->removeKey($jwkset->countKeys() - 1);
+
+        // Prepend new key to set
+        $jwkset->prependKey($this->createJWK());
+
+        // Save new key set
         $this->saveObject($jwkset);
+    }
+
+    /**
+     * Rotate key set if last modification time is due
+     */
+    private function rotateIfNeeded()
+    {
+        if (isset($this->interval) && $this->interval >= 0) {
+            $modificationTime = $this->getLastModificationTime();
+
+            if (null === $modificationTime) {
+                $this->regen();
+            } elseif (($modificationTime + $this->interval) < time()) {
+                $this->rotate();
+            }
+        }
     }
 }

--- a/src/Object/Storable.php
+++ b/src/Object/Storable.php
@@ -137,9 +137,13 @@ trait Storable
      */
     public function getLastModificationTime()
     {
+        clearstatcache(null, $this->getFilename());
+
         if (file_exists($this->getFilename())) {
             return filemtime($this->getFilename());
         }
+
+        return null;
     }
 
     /**

--- a/src/Object/StorableJWK.php
+++ b/src/Object/StorableJWK.php
@@ -27,7 +27,7 @@ class StorableJWK implements StorableInterface, JWKInterface
     protected $parameters;
 
     /**
-     * RotatableJWK constructor.
+     * StorableJWK constructor.
      *
      * @param string $filename
      * @param array  $parameters

--- a/src/Object/StorableJWKSet.php
+++ b/src/Object/StorableJWKSet.php
@@ -152,6 +152,14 @@ class StorableJWKSet implements StorableInterface, JWKSetInterface
     {
         // Not available
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function prependKey(JWKInterface $key)
+    {
+        //Not available
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Object/StorableJWKSet.php
+++ b/src/Object/StorableJWKSet.php
@@ -152,7 +152,7 @@ class StorableJWKSet implements StorableInterface, JWKSetInterface
     {
         // Not available
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Unit/Objects/RotatableJWKSetTest.php
+++ b/tests/Unit/Objects/RotatableJWKSetTest.php
@@ -13,18 +13,18 @@ use Jose\Factory\JWKFactory;
 use Jose\Object\JWKInterface;
 
 /**
- * Class StorableJWKSetTest.
+ * Class RotatableJWKSetTest.
  *
  * @group Unit
  * @group StorableJWKSet
+ * @group RotatableJWKSet
  */
-class StorableJWKSetTest extends \PHPUnit_Framework_TestCase
+class RotatableJWKSetTest extends \PHPUnit_Framework_TestCase
 {
     public function testKey()
     {
         @unlink(sys_get_temp_dir().'/JWKSet.key');
-
-        $jwkset = JWKFactory::createStorableKeySet(
+        $jwkset = JWKFactory::createRotatableKeySet(
             sys_get_temp_dir().'/JWKSet.key',
             [
                 'kty' => 'EC',
@@ -53,6 +53,12 @@ class StorableJWKSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($actual_content, json_encode($jwkset));
 
+        $jwkset->rotate();
+
+        $this->assertNotEquals($actual_content, json_encode($jwkset));
+
+        $actual_content = json_encode($jwkset);
+
         $jwkset[] = JWKFactory::createKey(['kty' => 'EC', 'crv' => 'P-521']);
         $this->assertEquals(3, $jwkset->count());
         $this->assertEquals(3, $jwkset->countKeys());
@@ -79,5 +85,48 @@ class StorableJWKSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($actual_content, json_encode($jwkset));
 
         $jwkset->delete();
+    }
+
+    public function testKeyInterval()
+    {
+        @unlink(sys_get_temp_dir().'/JWKSet.key');
+        $jwkset = JWKFactory::createRotatableKeySet(
+            sys_get_temp_dir().'/JWKSet.key',
+            [
+                'kty' => 'EC',
+                'crv' => 'P-256',
+            ],
+            3,
+            1 // 1 second rotation interval
+        );
+
+        $this->assertEquals(3, $jwkset->count());
+        $this->assertEquals(3, $jwkset->countKeys());
+
+        $before_rotate = json_decode(json_encode($jwkset))->keys;
+
+        // Sleep to ensure next calls trigger rotation
+        sleep(2);
+
+        // Make sure that a manual call to getKeys triggered rotation
+        $after_rotate = json_decode(json_encode($jwkset->getKeys()));
+
+        $this->assertCount(3, $after_rotate);
+        $this->assertEquals($before_rotate[0], $after_rotate[1]);
+        $this->assertEquals($before_rotate[1], $after_rotate[2]);
+
+        // Sleep to ensure next calls trigger rotation
+        sleep(2);
+
+        // Make sure that json serialization also triggered rotation
+        $after_second_rotate = json_decode(json_encode($jwkset))->keys;
+
+        $this->assertCount(3, $after_second_rotate);
+        $this->assertEquals($after_rotate[0], $after_second_rotate[1]);
+        $this->assertEquals($after_rotate[1], $after_second_rotate[2]);
+
+        // Make sure that subsequent calls to get keys within the interval period do not trigger rotation
+        $this->assertEquals($after_second_rotate, json_decode(json_encode($jwkset->getKeys())));
+        $this->assertEquals($after_second_rotate, json_decode(json_encode($jwkset))->keys);
     }
 }


### PR DESCRIPTION
Forked from `v6.1.5`

- Add interval argument for rotatable key set. When given, the rotatable key set will automatically rotate keys when interval has passed.
- Fix some minor documentation issues.
- Move BaseJWKSet from trait to abstract class because as the name suggests, it serves as a base for JWK sets, not as a trait.
- Add gitignore file to ignore vendor dir, local phpunit.xml (not .dist) and composer.lock. I would recommend committing the composer.lock, but that's not up to me so I excluded it for now.