### PR TITLE
Allow HHVM builds to fail as gmp_random_range isn’t implemented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: true
 matrix:
     allow_failures:
         - php: nightly
+        - php: hhvm
+        - php: hhvm
+          env: deps=low
     fast_finish: true
     include:
         - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     allow_failures:
         - php: nightly
         - php: hhvm
-        - php: hhvm
-          env: deps=low
     fast_finish: true
     include:
         - php: 5.6


### PR DESCRIPTION
The GMP extension isn’t fully implemented in HHVM as gmp_random_range is missing which is needed by BigInteger and used when working with RSA keys. Until a solution is found, RSA keys can’t be used with HHVM.