### PR TITLE
Allow for clock drift in checkers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 
 phpunit.xml
 composer.lock
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 phpunit.xml
 composer.lock
+.idea

--- a/src/Checker/ExpirationTimeChecker.php
+++ b/src/Checker/ExpirationTimeChecker.php
@@ -20,6 +20,7 @@ class ExpirationTimeChecker implements ClaimCheckerInterface
 
     public function __construct($tolerance = 0)
     {
+        Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');
         $this->tolerance = (int) $tolerance;
     }
 

--- a/src/Checker/ExpirationTimeChecker.php
+++ b/src/Checker/ExpirationTimeChecker.php
@@ -16,8 +16,14 @@ use Jose\Object\JWTInterface;
 
 class ExpirationTimeChecker implements ClaimCheckerInterface
 {
+    /**
+     * @var int
+     */
     private $tolerance;
 
+    /**
+     * @param int $tolerance
+     */
     public function __construct($tolerance = 0)
     {
         Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');

--- a/src/Checker/ExpirationTimeChecker.php
+++ b/src/Checker/ExpirationTimeChecker.php
@@ -16,6 +16,13 @@ use Jose\Object\JWTInterface;
 
 class ExpirationTimeChecker implements ClaimCheckerInterface
 {
+    private $tolerance;
+
+    public function __construct($tolerance = 0)
+    {
+        $this->tolerance = (int) $tolerance;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -25,8 +32,8 @@ class ExpirationTimeChecker implements ClaimCheckerInterface
             return [];
         }
 
-        $exp = (int) $jwt->getClaim('exp');
-        Assertion::greaterThan($exp, time(), 'The JWT has expired.');
+        $exp = (int) $jwt->getClaim('exp') + $this->tolerance;
+        Assertion::greaterOrEqualThan($exp, time(), 'The JWT has expired.');
 
         return ['exp'];
     }

--- a/src/Checker/IssuedAtChecker.php
+++ b/src/Checker/IssuedAtChecker.php
@@ -16,6 +16,13 @@ use Jose\Object\JWTInterface;
 
 class IssuedAtChecker implements ClaimCheckerInterface
 {
+    private $tolerance;
+
+    public function __construct($tolerance = 0)
+    {
+        $this->tolerance = (int) $tolerance;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +32,7 @@ class IssuedAtChecker implements ClaimCheckerInterface
             return [];
         }
 
-        $iat = (int) $jwt->getClaim('iat');
+        $iat = (int) $jwt->getClaim('iat') - $this->tolerance;
         Assertion::lessOrEqualThan($iat, time(), 'The JWT is issued in the future.');
 
         return ['iat'];

--- a/src/Checker/IssuedAtChecker.php
+++ b/src/Checker/IssuedAtChecker.php
@@ -20,6 +20,7 @@ class IssuedAtChecker implements ClaimCheckerInterface
 
     public function __construct($tolerance = 0)
     {
+        Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');
         $this->tolerance = (int) $tolerance;
     }
 

--- a/src/Checker/IssuedAtChecker.php
+++ b/src/Checker/IssuedAtChecker.php
@@ -16,8 +16,14 @@ use Jose\Object\JWTInterface;
 
 class IssuedAtChecker implements ClaimCheckerInterface
 {
+    /**
+     * @var int
+     */
     private $tolerance;
 
+    /**
+     * @param int $tolerance
+     */
     public function __construct($tolerance = 0)
     {
         Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');

--- a/src/Checker/NotBeforeChecker.php
+++ b/src/Checker/NotBeforeChecker.php
@@ -16,6 +16,13 @@ use Jose\Object\JWTInterface;
 
 class NotBeforeChecker implements ClaimCheckerInterface
 {
+    private $tolerance;
+
+    public function __construct($tolerance = 0)
+    {
+        $this->tolerance = (int) $tolerance;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +32,7 @@ class NotBeforeChecker implements ClaimCheckerInterface
             return [];
         }
 
-        $nbf = (int) $jwt->getClaim('nbf');
+        $nbf = (int) $jwt->getClaim('nbf') - $this->tolerance;
         Assertion::lessOrEqualThan($nbf, time(), 'The JWT can not be used yet.');
 
         return ['nbf'];

--- a/src/Checker/NotBeforeChecker.php
+++ b/src/Checker/NotBeforeChecker.php
@@ -20,6 +20,7 @@ class NotBeforeChecker implements ClaimCheckerInterface
 
     public function __construct($tolerance = 0)
     {
+        Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');
         $this->tolerance = (int) $tolerance;
     }
 

--- a/src/Checker/NotBeforeChecker.php
+++ b/src/Checker/NotBeforeChecker.php
@@ -16,8 +16,14 @@ use Jose\Object\JWTInterface;
 
 class NotBeforeChecker implements ClaimCheckerInterface
 {
+    /**
+     * @var int
+     */
     private $tolerance;
 
+    /**
+     * @param int $tolerance
+     */
     public function __construct($tolerance = 0)
     {
         Assertion::greaterOrEqualThan($tolerance, 0, 'Tolerance value must be >=0');

--- a/tests/Unit/Checker/CheckerTestCase.php
+++ b/tests/Unit/Checker/CheckerTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jose\Test\Unit\Checker {
+
+    use Jose\Checker\Clock;
+    use PHPUnit\Framework\TestCase;
+
+    abstract class CheckerTestCase extends TestCase
+    {
+        public function tearDown()
+        {
+            Clock::$mockedTime = false;
+        }
+
+        protected function mockCurrentTime($unixTime)
+        {
+            Clock::$mockedTime = (int) $unixTime;
+        }
+    }
+}
+
+namespace Jose\Checker {
+
+    class Clock {
+        public static $mockedTime = false;
+    }
+
+    function time() {
+        if (Clock::$mockedTime) {
+            return Clock::$mockedTime;
+        }
+
+        return \time();
+    }
+}

--- a/tests/Unit/Checker/CheckerTestCase.php
+++ b/tests/Unit/Checker/CheckerTestCase.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
 namespace Jose\Test\Unit\Checker {
 
     use Jose\Checker\Clock;
@@ -21,15 +30,18 @@ namespace Jose\Test\Unit\Checker {
 
 namespace Jose\Checker {
 
-    class Clock {
+    class Clock
+    {
         public static $mockedTime = false;
     }
 
-    function time() {
+    function time()
+    {
         if (Clock::$mockedTime) {
             return Clock::$mockedTime;
         }
 
         return \time();
     }
+
 }

--- a/tests/Unit/Checker/CheckerTestCase.php
+++ b/tests/Unit/Checker/CheckerTestCase.php
@@ -10,7 +10,6 @@
  */
 
 namespace Jose\Test\Unit\Checker {
-
     use Jose\Checker\Clock;
     use PHPUnit\Framework\TestCase;
 
@@ -29,7 +28,6 @@ namespace Jose\Test\Unit\Checker {
 }
 
 namespace Jose\Checker {
-
     class Clock
     {
         public static $mockedTime = false;
@@ -43,5 +41,4 @@ namespace Jose\Checker {
 
         return \time();
     }
-
 }

--- a/tests/Unit/Checker/ExpirationTimeCheckerTest.php
+++ b/tests/Unit/Checker/ExpirationTimeCheckerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jose\Test\Unit\Checker;
+
+use Assert\InvalidArgumentException;
+use Jose\Checker\ExpirationTimeChecker;
+use Jose\Factory\JWSFactory;
+
+class ExpirationTimeCheckerTest extends CheckerTestCase
+{
+    /** @var  ExpirationTimeChecker */
+    private $checker;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->checker = new ExpirationTimeChecker();
+    }
+
+
+    public function testItReturnsEmptyArrayIfNoExpiryClaim()
+    {
+        $jws = JWSFactory::createJWS([]);
+
+        $result = $this->checker->checkClaim($jws);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testItThrowsExceptionIfTokenHasExpired()
+    {
+        $jws = JWSFactory::createJWS(['exp' => 1234]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JWT has expired.');
+
+        $this->checker->checkClaim($jws);
+    }
+
+    public function testItReturnsExpIfTokenIsStillValid()
+    {
+        $jws = JWSFactory::createJWS(['exp' => 64625299200]); // 11/23/4017 @ 12:00am (UTC)
+
+        $result = $this->checker->checkClaim($jws);
+
+        $this->assertEquals(['exp'], $result);
+    }
+
+    public function testItReturnsOkIfExpiryWithinTolerance()
+    {
+        $expiryTime = 1000;
+        $tolerance = 300;
+        $checker = new ExpirationTimeChecker($tolerance);
+        $jws = JWSFactory::createJWS(['exp' => $expiryTime]);
+        $this->mockCurrentTime($tolerance + $expiryTime);
+
+        $result = $checker->checkClaim($jws);
+
+        $this->assertEquals(['exp'], $result);
+    }
+}

--- a/tests/Unit/Checker/ExpirationTimeCheckerTest.php
+++ b/tests/Unit/Checker/ExpirationTimeCheckerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
 namespace Jose\Test\Unit\Checker;
 
 use Assert\InvalidArgumentException;
@@ -8,7 +17,7 @@ use Jose\Factory\JWSFactory;
 
 class ExpirationTimeCheckerTest extends CheckerTestCase
 {
-    /** @var  ExpirationTimeChecker */
+    /** @var ExpirationTimeChecker */
     private $checker;
 
     public function setUp()
@@ -17,7 +26,6 @@ class ExpirationTimeCheckerTest extends CheckerTestCase
 
         $this->checker = new ExpirationTimeChecker();
     }
-
 
     public function testItReturnsEmptyArrayIfNoExpiryClaim()
     {
@@ -67,4 +75,5 @@ class ExpirationTimeCheckerTest extends CheckerTestCase
 
         new ExpirationTimeChecker(-100);
     }
+
 }

--- a/tests/Unit/Checker/ExpirationTimeCheckerTest.php
+++ b/tests/Unit/Checker/ExpirationTimeCheckerTest.php
@@ -75,5 +75,4 @@ class ExpirationTimeCheckerTest extends CheckerTestCase
 
         new ExpirationTimeChecker(-100);
     }
-
 }

--- a/tests/Unit/Checker/ExpirationTimeCheckerTest.php
+++ b/tests/Unit/Checker/ExpirationTimeCheckerTest.php
@@ -59,4 +59,12 @@ class ExpirationTimeCheckerTest extends CheckerTestCase
 
         $this->assertEquals(['exp'], $result);
     }
+
+    public function testItThrowsExceptionIfNegativeToleranceValueProvided()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tolerance value must be >=0');
+
+        new ExpirationTimeChecker(-100);
+    }
 }

--- a/tests/Unit/Checker/IssuedAtCheckerTest.php
+++ b/tests/Unit/Checker/IssuedAtCheckerTest.php
@@ -57,4 +57,13 @@ class IssuedAtCheckerTest extends CheckerTestCase
 
         $this->assertEquals(['iat'], $result);
     }
+
+    public function testItThrowsExceptionIfNegativeToleranceValueProvided()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tolerance value must be >=0');
+
+        new IssuedAtChecker(-100);
+    }
+
 }

--- a/tests/Unit/Checker/IssuedAtCheckerTest.php
+++ b/tests/Unit/Checker/IssuedAtCheckerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jose\Test\Unit\Checker;
+
+use Assert\InvalidArgumentException;
+use Jose\Checker\IssuedAtChecker;
+use Jose\Factory\JWSFactory;
+
+class IssuedAtCheckerTest extends CheckerTestCase
+{
+    /** @var  IssuedAtChecker */
+    private $checker;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->checker = new IssuedAtChecker();
+    }
+
+    public function testItReturnsEmptyArrayIfNoIatClaim()
+    {
+        $jws = JWSFactory::createJWS([]);
+
+        $result = $this->checker->checkClaim($jws);
+
+        $this->assertEquals([], $result);
+    }
+
+    public function testItThrowsExceptionIfIssuedInTheFuture()
+    {
+        $jws = JWSFactory::createJWS(['iat' => '64625299200']); // 11/23/4017 @ 12:00am (UTC)
+
+        $this->expectExceptionMessage('The JWT is issued in the future.');
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->checker->checkClaim($jws);
+    }
+
+    public function testItReturnsOkIfIssuedInThePast()
+    {
+        $jws = JWSFactory::createJWS(['iat' => time() - 1000 ]);
+
+        $result = $this->checker->checkClaim($jws);
+
+        $this->assertEquals(['iat'], $result);
+    }
+
+    public function testItReturnsOkIfIssuedInFutureWithinTolerance()
+    {
+        $issuedAtTime = 1000;
+        $tolerance    = 300;
+        $jws = JWSFactory::createJWS(['iat' => $issuedAtTime]);
+        $this->mockCurrentTime($issuedAtTime - $tolerance);
+
+        $checker = new IssuedAtChecker($tolerance);
+        $result = $checker->checkClaim($jws);
+
+        $this->assertEquals(['iat'], $result);
+    }
+}

--- a/tests/Unit/Checker/IssuedAtCheckerTest.php
+++ b/tests/Unit/Checker/IssuedAtCheckerTest.php
@@ -74,5 +74,4 @@ class IssuedAtCheckerTest extends CheckerTestCase
 
         new IssuedAtChecker(-100);
     }
-
 }

--- a/tests/Unit/Checker/IssuedAtCheckerTest.php
+++ b/tests/Unit/Checker/IssuedAtCheckerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
 namespace Jose\Test\Unit\Checker;
 
 use Assert\InvalidArgumentException;
@@ -8,7 +17,7 @@ use Jose\Factory\JWSFactory;
 
 class IssuedAtCheckerTest extends CheckerTestCase
 {
-    /** @var  IssuedAtChecker */
+    /** @var IssuedAtChecker */
     private $checker;
 
     public function setUp()
@@ -38,7 +47,7 @@ class IssuedAtCheckerTest extends CheckerTestCase
 
     public function testItReturnsOkIfIssuedInThePast()
     {
-        $jws = JWSFactory::createJWS(['iat' => time() - 1000 ]);
+        $jws = JWSFactory::createJWS(['iat' => time() - 1000]);
 
         $result = $this->checker->checkClaim($jws);
 
@@ -48,7 +57,7 @@ class IssuedAtCheckerTest extends CheckerTestCase
     public function testItReturnsOkIfIssuedInFutureWithinTolerance()
     {
         $issuedAtTime = 1000;
-        $tolerance    = 300;
+        $tolerance = 300;
         $jws = JWSFactory::createJWS(['iat' => $issuedAtTime]);
         $this->mockCurrentTime($issuedAtTime - $tolerance);
 

--- a/tests/Unit/Checker/NotBeforeCheckerTest.php
+++ b/tests/Unit/Checker/NotBeforeCheckerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2017 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
 namespace Jose\Test\Unit\Checker;
 
 use Assert\InvalidArgumentException;
@@ -56,4 +65,5 @@ class NotBeforeCheckerTest extends CheckerTestCase
 
         new NotBeforeChecker(-100);
     }
+
 }

--- a/tests/Unit/Checker/NotBeforeCheckerTest.php
+++ b/tests/Unit/Checker/NotBeforeCheckerTest.php
@@ -65,5 +65,4 @@ class NotBeforeCheckerTest extends CheckerTestCase
 
         new NotBeforeChecker(-100);
     }
-
 }

--- a/tests/Unit/Checker/NotBeforeCheckerTest.php
+++ b/tests/Unit/Checker/NotBeforeCheckerTest.php
@@ -48,4 +48,12 @@ class NotBeforeCheckerTest extends CheckerTestCase
 
         $this->assertEquals(['nbf'], $result);
     }
+
+    public function testItThrowsExceptionIfNegativeToleranceValueProvided()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tolerance value must be >=0');
+
+        new NotBeforeChecker(-100);
+    }
 }

--- a/tests/Unit/Checker/NotBeforeCheckerTest.php
+++ b/tests/Unit/Checker/NotBeforeCheckerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Jose\Test\Unit\Checker;
+
+use Assert\InvalidArgumentException;
+use Jose\Checker\NotBeforeChecker;
+use Jose\Factory\JWSFactory;
+
+class NotBeforeCheckerTest extends CheckerTestCase
+{
+    /** @var NotBeforeChecker */
+    private $checker;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->checker = new NotBeforeChecker();
+    }
+
+    public function testItReturnsEmptyArrayIfNoNbfClaim()
+    {
+        $jws = JWSFactory::createJWS([]);
+
+        $result = $this->checker->checkClaim($jws);
+        $this->assertEquals([], $result);
+    }
+
+    public function testItThrowsExceptionIfCurrentTimeIsBeforeNotBeforeClaim()
+    {
+        $jws = JWSFactory::createJWS(['nbf' => time() + 1000]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The JWT can not be used yet.');
+
+        $this->checker->checkClaim($jws);
+    }
+
+    public function testItReturnsOkIfCurrentTimeAfterNbfClaim()
+    {
+        $notBefore = time();
+        $tolerance = 300;
+        $jws = JWSFactory::createJWS(['nbf' => $notBefore]);
+        $checker = new NotBeforeChecker($tolerance);
+        $this->mockCurrentTime($notBefore - $tolerance);
+
+        $result = $checker->checkClaim($jws);
+
+        $this->assertEquals(['nbf'], $result);
+    }
+}


### PR DESCRIPTION
We get our JWTs from a third party service which has on occasion had it's clock set differently to our server.

The `Expiration`, `IssuedAt` and `NotBefore` Checkers are quite strict at what is allowed. This PR adds a optional tolerance value to account for any clock drift. 

The default value is `0` to preserve existing behaviour and I've added test coverage to account for original and new cases.