### PR TITLE
Custom http headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.0",
         "lib-openssl": "*",
         "spomky-labs/base64url": "^1.0",
-        "spomky-labs/aes-key-wrap": "^3.0",
+        "spomky-labs/aes-key-wrap": "^3.0|^4.0",
         "spomky-labs/php-aes-gcm": "^1.2",
         "beberlei/assert": "^2.4",
         "symfony/polyfill-mbstring": "^1.1",
@@ -37,9 +37,9 @@
         "psr/cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "satooshi/php-coveralls": "^1.0",
-        "symfony/cache": "^2.0|^3.0"
+        "phpunit/phpunit": "^7.0",
+        "satooshi/php-coveralls": "^2.0",
+        "symfony/cache": "^2.0|^3.0|^4.0"
     },
    "suggest":{
         "ext-crypto": "Highly recommended when you use AES GCM based algorithms.",
@@ -48,7 +48,7 @@
    },
     "extra": {
         "branch-alias": {
-            "dev-master": "7.0.x-dev"
+            "dev-master": "7.1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "psr/cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.0",
         "satooshi/php-coveralls": "^2.0",
         "symfony/cache": "^2.0|^3.0|^4.0"
     },

--- a/examples/NestedTokens1.php
+++ b/examples/NestedTokens1.php
@@ -51,4 +51,3 @@ $jwe = JWEFactory::createJWEToCompactJSON(
         'zip' => 'DEF',
     ]
 );
-var_dump($jwe);

--- a/src/Factory/JWKFactory.php
+++ b/src/Factory/JWKFactory.php
@@ -366,17 +366,17 @@ final class JWKFactory implements JWKFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public static function createFromJKU($jku, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false)
+    public static function createFromJKU($jku, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false, array $custom_headers = [])
     {
-        return new JKUJWKSet($jku, $cache, $ttl, $allow_unsecured_connection, $allow_http_connection);
+        return new JKUJWKSet($jku, $cache, $ttl, $allow_unsecured_connection, $allow_http_connection, $custom_headers);
     }
 
     /**
      * {@inheritdoc}
      */
-    public static function createFromX5U($x5u, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false)
+    public static function createFromX5U($x5u, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false, array $custom_headers = [])
     {
-        return new X5UJWKSet($x5u, $cache, $ttl, $allow_unsecured_connection, $allow_http_connection);
+        return new X5UJWKSet($x5u, $cache, $ttl, $allow_unsecured_connection, $allow_http_connection, $custom_headers);
     }
 
     /**

--- a/src/Factory/JWKFactoryInterface.php
+++ b/src/Factory/JWKFactoryInterface.php
@@ -154,10 +154,11 @@ interface JWKFactoryInterface
      * @param \Psr\Cache\CacheItemPoolInterface|null $cache
      * @param int|null                               $ttl
      * @param bool                                   $allow_http_connection
+     * @param array                                  $custom_headers
      *
      * @return \Jose\Object\JWKSetInterface
      */
-    public static function createFromJKU($jku, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false);
+    public static function createFromJKU($jku, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false, array $custom_headers = []);
 
     /**
      * @param string                                 $x5u
@@ -165,10 +166,11 @@ interface JWKFactoryInterface
      * @param \Psr\Cache\CacheItemPoolInterface|null $cache
      * @param int|null                               $ttl
      * @param bool                                   $allow_http_connection
+     * @param array                                  $custom_headers
      *
      * @return \Jose\Object\JWKSetInterface
      */
-    public static function createFromX5U($x5u, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false);
+    public static function createFromX5U($x5u, $allow_unsecured_connection = false, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_http_connection = false, array $custom_headers = []);
 
     /**
      * @param array $x5c

--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -42,6 +42,11 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
     private $allow_unsecured_connection;
 
     /**
+     * @var array
+     */
+    private $custom_headers = [];
+
+    /**
      * DownloadedJWKSet constructor.
      *
      * @param string                                 $url
@@ -49,8 +54,9 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
      * @param int                                    $ttl
      * @param bool                                   $allow_unsecured_connection
      * @param bool                                   $allow_http_connection
+     * @param array                                  $cache
      */
-    public function __construct($url, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_unsecured_connection = false, $allow_http_connection = false)
+    public function __construct($url, CacheItemPoolInterface $cache = null, $ttl = 86400, $allow_unsecured_connection = false, $allow_http_connection = false, array $custom_headers = [])
     {
         Assertion::boolean($allow_unsecured_connection);
         Assertion::boolean($allow_http_connection);
@@ -67,6 +73,7 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
         $this->cache = $cache;
         $this->ttl = $ttl;
         $this->allow_unsecured_connection = $allow_unsecured_connection;
+        $this->custom_headers = $custom_headers;
     }
 
     /**
@@ -139,6 +146,9 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
 
         $ch = curl_init();
         curl_setopt_array($ch, $params);
+        if (!empty($this->custom_headers)) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $this->custom_headers);
+        }
         $content = curl_exec($ch);
 
         try {


### PR DESCRIPTION
This PR fixes #321.
An additional argument for the JKU/X5U key set allows custom headers such as Authorization or X-Foo-Bar to be set.