### PR TITLE
Little config settings

### DIFF
--- a/src/Factory/JWKFactory.php
+++ b/src/Factory/JWKFactory.php
@@ -92,6 +92,9 @@ final class JWKFactory implements JWKFactoryInterface
      */
     public static function createRSAKey(array $values)
     {
+        $config = array();
+        $config['config'] = dirname(__FILE__) . '/../openssl.cnf';
+
         Assertion::keyExists($values, 'size', 'The key size is not set.');
         $size = $values['size'];
         unset($values['size']);
@@ -102,13 +105,16 @@ final class JWKFactory implements JWKFactoryInterface
         $key = openssl_pkey_new([
             'private_key_bits' => $size,
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
-        ]);
-        openssl_pkey_export($key, $out);
+        ] + $config);
+        openssl_pkey_export($key, $out, null, $config);
         $rsa = new RSAKey($out);
         $values = array_merge(
             $values,
             $rsa->toArray()
         );
+
+        //            $privatekey = call_user_func_array(array($this, '_convertPrivateKey'), array_values($this->_parseKey($privatekey, self::PRIVATE_FORMAT_PKCS1)));
+        //            $publickey = call_user_func_array(array($this, '_convertPublicKey'), array_values($this->_parseKey($publickey, self::PUBLIC_FORMAT_PKCS1)));
 
         return new JWK($values);
     }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Álvaro
+ * Date: 09/05/2018
+ * Time: 3:28
+ */
+
+// DECRYPT
+
+require( __DIR__ . "/../assert/Assert.php");
+require( __DIR__ . "/../assert/Assertion.php");
+require( __DIR__ . "/../assert/AssertionFailedException.php");
+require( __DIR__ . "/../assert/InvalidArgumentException.php");
+
+require(__DIR__ . "/../fg/Utility/BigInteger.php");
+require(__DIR__ . "/../fg/Utility/BigIntegerGmp.php");
+require(__DIR__ . "/../fg/ASN1/Parsable.php");
+require(__DIR__ . "/../fg/ASN1/ASNObject.php");
+require(__DIR__ . "/../fg/ASN1/Construct.php");
+require(__DIR__ . "/../fg/ASN1/Identifier.php");
+require(__DIR__ . "/../fg/ASN1/Universal/Sequence.php");
+require(__DIR__ . "/../fg/ASN1/Universal/Integer.php");
+
+require(__DIR__ . "/../fg/ASN1/Base128.php");
+
+require(__DIR__ . "/../fg/ASN1/Universal/ObjectIdentifier.php");
+require(__DIR__ . "/../fg/ASN1/Universal/NullObject.php");
+require(__DIR__ . "/../fg/ASN1/Universal/OctetString.php");
+
+require(__DIR__ . "/../base64url/Base64Url.php");
+
+require("Util/BigInteger.php");
+
+require("Algorithm/JWAInterface.php");
+require("Algorithm/KeyEncryptionAlgorithmInterface.php");
+require("Algorithm/KeyEncryption/KeyEncryptionInterface.php");
+
+require("Util/Hash.php");
+require("Util/RSA.php");
+
+require("Algorithm/KeyEncryption/RSA.php");
+require("Algorithm/KeyEncryption/RSAOAEP.php");
+require("Algorithm/JWAManagerInterface.php");
+require("Algorithm/JWAManager.php");
+
+require("Algorithm/ContentEncryptionAlgorithmInterface.php");
+
+require(__DIR__ . "/../php-aes-gcm/AESGCM.php");
+
+// For decrypt
+require("Algorithm/ContentEncryption/AESGCM.php");
+require("Algorithm/ContentEncryption/A256GCM.php");
+
+// For encrypt
+
+// RSA-OAEP-256
+require("Algorithm/ContentEncryption/AESCBCHS.php");
+require("Algorithm/ContentEncryption/A256CBCHS512.php");
+require("Algorithm/KeyEncryption/RSAOAEP256.php");
+
+//A256GCMKW
+require("Algorithm/KeyEncryption/KeyWrappingInterface.php");
+require("Algorithm/KeyEncryption/AESGCMKW.php");
+require("Algorithm/KeyEncryption/A256GCMKW.php");
+
+require("Factory/AlgorithmManagerFactory.php");
+
+require("Compression/CompressionInterface.php");
+require("Compression/GZip.php");
+require("Compression/ZLib.php");
+require("Compression/Deflate.php");
+require("Compression/CompressionManagerInterface.php");
+require("Compression/CompressionManager.php");
+require("Factory/CompressionManagerFactory.php");
+
+require("Behaviour/CommonCipheringMethods.php");
+require("Behaviour/HasCompressionManager.php");
+require("Behaviour/HasJWAManager.php");
+require("Behaviour/HasKeyChecker.php");
+
+require("DecrypterInterface.php");
+require("Decrypter.php");
+
+require("Object/RecipientInterface.php");
+require("Object/Recipient.php");
+
+require("Object/JWTInterface.php");
+require("Object/JWT.php");
+require("Object/JWEInterface.php");
+require("Object/JWE.php");
+require("Util/JWELoader.php");
+
+require("Object/BaseJWKSet.php");
+require("Object/JWKSetInterface.php");
+require("Object/JWKSetPEM.php");
+require("Object/JWKSet.php");
+require("Object/JWKInterface.php");
+require("Object/JWK.php");
+
+require(__DIR__ . "/../fg/ASN1/Universal/BitString.php");
+
+require("KeyConverter/RSAKey.php");
+require("KeyConverter/KeyConverter.php");
+require("Factory/JWKFactoryInterface.php");
+require("Factory/JWKFactory.php");
+require("LoaderInterface.php");
+require("Loader.php");
+
+// ENCRYPT
+
+require("Behaviour/EncrypterTrait.php");
+require("EncrypterInterface.php");
+require("Encrypter.php");
+require("Factory/JWEFactoryInterface.php");
+require("Factory/JWEFactory.php");

--- a/src/openssl.cnf
+++ b/src/openssl.cnf
@@ -1,0 +1,6 @@
+# minimalist openssl.cnf file for use with phpseclib
+
+HOME			= .
+RANDFILE		= $ENV::HOME/.rnd
+
+[ v3_ca ]


### PR DESCRIPTION
In some cases the following error occurs:

> Warning: openssl_pkey_export() [function.openssl-pkey-export]: cannot get key from parameter 1 in C:\wamp\www\opensslsample\index.php on line 18
> 
> Warning: openssl_pkey_get_details() expects parameter 1 to be resource, boolean given in C:\wamp\www\opensslsample\index.php on line 21

Extracted from: https://stackoverflow.com/a/50257146/3286975

I cannot reproduce right now, but in some cases it occurs.

I also added autoload for non POO projects, I can divide this commit into two if you don't to add it.

Oh... I didn't want to put those lines:

```
$privatekey = call_user_func_array(array($this, '_convertPrivateKey'), array_values($this->_parseKey($privatekey, self::PRIVATE_FORMAT_PKCS1)));
$publickey = call_user_func_array(array($this, '_convertPublicKey'), array_values($this->_parseKey($publickey, self::PUBLIC_FORMAT_PKCS1)));
```

They are from the [on-going investigation issue](https://github.com/Spomky-Labs/jose/issues/326). Sorry 😞
 
