### PR TITLE
allow self-signed SSL certificates

### DIFF
--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -138,12 +138,12 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
         $params = [
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_URL => $this->url,
-            CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSL_VERIFYHOST => false
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 1
         ];
-        if (false === $this->allow_unsecured_connection) {
-            $params[CURLOPT_SSL_VERIFYPEER] = true;
-            $params[CURLOPT_SSL_VERIFYHOST] = 2;
+        if ($this->allow_unsecured_connection) {
+            $params[CURLOPT_SSL_VERIFYPEER] = false;
+            $params[CURLOPT_SSL_VERIFYHOST] = false;
         }
 
         $ch = curl_init();

--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -138,6 +138,8 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
         $params = [
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_URL => $this->url,
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => false
         ];
         if (false === $this->allow_unsecured_connection) {
             $params[CURLOPT_SSL_VERIFYPEER] = true;


### PR DESCRIPTION
set CURLOPT_SSL_VERIFYPEER and CURLOPT_SSL_VERIFYHOST to false to allow self-signed SSL certificates