### PR TITLE
Remove deprecated FILTER_FLAG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED

### DIFF
--- a/src/Object/DownloadedJWKSet.php
+++ b/src/Object/DownloadedJWKSet.php
@@ -62,7 +62,7 @@ abstract class DownloadedJWKSet extends BaseJWKSet implements JWKSetInterface
         Assertion::boolean($allow_http_connection);
         Assertion::integer($ttl);
         Assertion::min($ttl, 0);
-        Assertion::false(false === filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED), 'Invalid URL.');
+        Assertion::false(false === filter_var($url, FILTER_VALIDATE_URL), 'Invalid URL.');
         $allowed_protocols = ['https'];
         if (true === $allow_http_connection) {
             $allowed_protocols[] = 'http';


### PR DESCRIPTION
> All you have to do is simply remove these two flags, because both of them are implied when you use FILTER_VALIDATE_URL.


https://php.watch/versions/7.3/filter-var-flag-deprecation